### PR TITLE
sleep 15 segundos, para startar o mongo no travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ notifications:
   irc: 'chat.freenode.net#nodebr'
 services:
   - mongodb
+before_script:
+  - sleep 15


### PR DESCRIPTION
O Travis com o mongo pode não aceitar a conexão rapidamente, por isso recomendaram colocar um sleep de 15 segundos. #24 

http://docs.travis-ci.com/user/database-setup/#MongoDB
